### PR TITLE
ヘッダーのレイアウト作成

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -23,14 +23,12 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
-            "scripts": []
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
+            "scripts": [],
+            "stylePreprocessorOptions": {
+              "includePaths": ["src/styles"]
+            }
           },
           "configurations": {
             "production": {
@@ -87,13 +85,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },
@@ -105,9 +98,7 @@
               "tsconfig.spec.json",
               "e2e/tsconfig.json"
             ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,1 +1,14 @@
-<p>header works!</p>
+<header class="header">
+  <div class="container-full">
+    <div class="header__inner">
+      <h1 class="header__title">
+        <a href="" class="header__logo-link">LOGO</a>
+      </h1>
+      <div class="header__actions">
+        <button class="header__login">
+          <span class="pc-only">Googleアカウントで</span>ログイン
+        </button>
+      </div>
+    </div>
+  </div>
+</header>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -1,0 +1,43 @@
+@import '~@angular/material/theming';
+
+:host {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background-color: #fff;
+}
+
+.header {
+  &__inner {
+    min-height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  &__title {
+    margin: 0;
+    font-size: 18px;
+  }
+  &__logo-link {
+    color: map-get($mat-cyan, 500);
+    text-decoration: none;
+  }
+  &__login {
+    cursor: pointer;
+    display: inline-block;
+    border: none;
+    background-color: map-get($mat-cyan, 500);
+    color: #fff;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 0.75em 1.25em;
+    border-radius: 0.25em;
+    box-shadow: 0 3px 6px -2px rgba(100, 110, 167, 0.2);
+    transition: opacity 0.4s;
+    &:hover {
+      opacity: 0.6;
+    }
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -31,18 +31,44 @@ $team-mitsui-theme: mat-light-theme(
 
 /* You can add global styles to this file, and also import other style files */
 
+@import 'variables';
+@import 'mixins';
+
 html,
 body {
   height: 100%;
 }
 body {
   margin: 0;
+  padding-top: 48px;
   font-family: 'Helvetica Neue', 'BlinkMacSystemFont',
     'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
+  color: $color-font;
 }
 
 .container {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 24px;
+  padding: 0 16px;
+  @include md {
+    padding: 0 24px;
+  }
+}
+.container-full {
+  margin: 0 auto;
+  padding: 0 16px;
+  @include md {
+    padding: 0 24px;
+  }
+}
+
+.sp-only {
+  @include md {
+    display: none !important;
+  }
+}
+.pc-only {
+  @include sm {
+    display: none !important;
+  }
 }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,0 +1,17 @@
+@mixin sm {
+  @media screen and (max-width: 599px) {
+    @content;
+  }
+}
+
+@mixin md {
+  @media screen and (min-width: 600px) {
+    @content;
+  }
+}
+
+@mixin lg {
+  @media screen and (min-width: 1200px) {
+    @content;
+  }
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,0 +1,6 @@
+@import '~@angular/material/theming';
+
+$color-main: map-get($mat-cyan, 500);
+$color-accent: map-get($mat-lime, 500);
+$color-base: map-get($mat-cyan, 50);
+$color-font: map-get($mat-grey, 900);


### PR DESCRIPTION
fix #4 

## 実装イメージ
SP
![localhost_4200_](https://user-images.githubusercontent.com/46749854/95645106-ebd88400-0af6-11eb-961c-fafa8c3fc032.png)

PC
![localhost_4200_ (1)](https://user-images.githubusercontent.com/46749854/95645104-e7ac6680-0af6-11eb-9576-f00cda4a7b48.png)


## 作業概要
レイアウトを作成しました。
メインカラーの設定や、ボタンのデザインは、後ほど行います。
